### PR TITLE
Add default keyword into package.json templates

### DIFF
--- a/templates/function/package.json.mustache
+++ b/templates/function/package.json.mustache
@@ -7,5 +7,8 @@
         "nodes": {
             "{{&nodeName}}": "node.js"
         }
-    }
+    },
+    "keywords": [
+        "node-red-nodegen"
+    ]
 }

--- a/templates/swagger/package.json.mustache
+++ b/templates/swagger/package.json.mustache
@@ -8,6 +8,9 @@
             "{{&nodeName}}": "node.js"
         }
     },
+    "keywords": [
+        "node-red-nodegen"
+    ],
     "dependencies": {
         "q": "1.5.1",
         "request": "2.83.0"


### PR DESCRIPTION
## Types of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes
I added default keyword, "node-red-nodegen" into package.json templates. It will be useful for Node-RED users to search nodes created by node generator.
