### PR TITLE
Fix Travis error

### DIFF
--- a/test/nodegen/node-red-contrib-swagger-petstore/node_spec.js
+++ b/test/nodegen/node-red-contrib-swagger-petstore/node_spec.js
@@ -44,8 +44,12 @@ describe('node-red-contrib-swagger-petstore', function () {
             var n1 = helper.getNode('n1');
             var n3 = helper.getNode('n3');
             n3.on('input', function (msg) {
-                msg.payload.should.have.property('123');
-                done();
+                try {
+                    msg.payload.should.have.property('available');
+                    done();
+                } catch (e) {
+                    done(e);
+                }
             });
             n1.receive({});
         });


### PR DESCRIPTION
## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
Current test case for swagger node fails because there isn't the key, "123" in the data from swagger petstore server.
I changed "123" to "available" which the server returns as default key.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality

