### PR TITLE
Use petstore on docker instead of petstore.swagger.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: false
 language: node_js
+services:
+  - docker
 env:
   - CXX="g++-4.8"
 addons:
@@ -9,14 +11,17 @@ addons:
     packages:
     - g++-4.8
     - gcc-4.8
+  hosts:
+    - petstore.swagger.io 
 node_js:
   - "8"
-  - "7"
   - "6"
   - "4"
 script:
   - istanbul cover ./node_modules/.bin/grunt --report lcovonly && istanbul report text && ( cat coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js || true ) && rm -rf coverage
 before_script:
+  - docker pull swaggerapi/petstore
+  - docker run -d -e SWAGGER_HOST=http://petstore.swagger.io -e SWAGGER_BASE_PATH=/v2 -p 80:8080 swaggerapi/petstore
   - npm install -g istanbul
   - npm install coveralls
   - npm install git+https://github.com/node-red/node-red.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ script:
   - istanbul cover ./node_modules/.bin/grunt --report lcovonly && istanbul report text && ( cat coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js || true ) && rm -rf coverage
 before_script:
   - docker pull swaggerapi/petstore
-  - docker run -d -e SWAGGER_HOST=http://petstore.swagger.io -e SWAGGER_BASE_PATH=/v2 -p 80:8080 swaggerapi/petstore
+  - docker run -d -e SWAGGER_URL=http://petstore.swagger.io -e SWAGGER_BASE_PATH=/v2 -p 80:8080 swaggerapi/petstore
   - npm install -g istanbul
   - npm install coveralls
   - npm install git+https://github.com/node-red/node-red.git


### PR DESCRIPTION
## Types of changes
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
Currently test cases for petstore use http://petstore.swagger.io .
I changed it to use petstore on docker on travis. 
and I removed node.js v7 from travis because node.js v7 is not LTS.

## Checklist
- [X] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [X] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality

