### PR TITLE
--keywords and --category options

### DIFF
--- a/bin/node-red-nodegen.js
+++ b/bin/node-red-nodegen.js
@@ -33,6 +33,8 @@ var data = {
     name: argv.name || argv.n,
     module: argv.module,
     version: argv.version || argv.v,
+    keywords: argv.keywords || argv.k,
+    category: argv.category || argv.c,
     dst: argv.output || argv.o || '.'
 };
 
@@ -44,6 +46,8 @@ function help() {
         ' [--name <node name>]' +
         ' [--module <module name>]' +
         ' [--version <version number>' +
+        ' [--keywords <keywords list>' +
+        ' [--category <node category>' +
         //' [--icon <png or gif file>' +
         //' [--color <node color>' +
         ' [--tgz]' +
@@ -63,6 +67,8 @@ function help() {
         '   --name : Node name (default: name defined in source)\n' +
         '   --module : Module name (default: "node-red-contrib-<node name>")\n' +
         '   --version : Node version (format: "number.number.number" like "4.5.1")\n' +
+        '   --keywords : Additional keywords (format: comma separated string, default: "node-red-nodegen")\n' +
+        '   --category : Node category (default: "function")\n' +
         //'   --icon : png or gif file for node appearance (image size should be 10x20)\n';
         //'   --color : color for node appearance (format: color hexadecimal numbers like "#A6BBCF")\n';
         '   --tgz : Save node as tgz file\n' +

--- a/lib/nodegen.js
+++ b/lib/nodegen.js
@@ -20,6 +20,7 @@ var request = require('request');
 var mustache = require('mustache');
 var jsStringEscape = require('js-string-escape');
 var obfuscator = require('javascript-obfuscator');
+var csv = require('csv-string');
 var CodeGen = require('swagger-js-codegen').CodeGen;
 
 function createCommonFiles(templateDirectory, data) {
@@ -87,6 +88,14 @@ function runNpmPack(data) {
     }
 }
 
+function extractKeywords(keywordsStr) {
+    var keywords = ["node-red-nodegen"];
+    keywords = keywordsStr ? keywords.concat(csv.parse(keywordsStr)[0]) : keywords;    
+    keywords = keywords.map(k => ({ name: k }));
+    keywords[keywords.length - 1].last = true;
+    return keywords;
+}
+
 function function2node(data, options) {
     // Read meta data in js file
     var meta = {};
@@ -129,6 +138,8 @@ function function2node(data, options) {
             nodeName: data.name,
             projectName: data.module,
             projectVersion: data.version,
+            keywords: extractKeywords(data.keywords),
+            category: data.category || 'function',
             func: jsStringEscape(data.src),
             outputs: meta.outputs
         };
@@ -244,7 +255,7 @@ function swagger2node(data, options) {
         nodejsSourceCode = obfuscator.obfuscate(nodejsSourceCode, { stringArrayEncoding: 'rc4' });
     }
     fs.writeFileSync(data.dst + '/' + data.module + '/lib.js', nodejsSourceCode);
-
+    
     // Create package.json
     var packageSourceCode = CodeGen.getCustomCode({
         className: className,
@@ -258,6 +269,7 @@ function swagger2node(data, options) {
             nodeName: data.name,
             projectName: data.module,
             projectVersion: data.version,
+            keywords: extractKeywords(data.keywords),
             licenseName: function () {
                 if (swagger.info.license && swagger.info.license.name) {
                     return swagger.info.license.name;
@@ -303,6 +315,7 @@ function swagger2node(data, options) {
         },
         mustache: {
             nodeName: data.name,
+            category: data.category || 'function'
         },
         lint: false,
         beautify: false

--- a/package.json
+++ b/package.json
@@ -43,14 +43,15 @@
         "swagger-codegen"
     ],
     "dependencies": {
-        "request": "2.83.0",
-        "yamljs": "0.3.0",
-        "mustache": "2.3.0",
-        "js-string-escape": "1.0.1",
+        "colors": "1.1.2",
+        "csv-string": "^3.1.2",
         "javascript-obfuscator": "0.12.2",
-        "swagger-js-codegen": "1.12.0",
+        "js-string-escape": "1.0.1",
         "minimist": "1.2.0",
-        "colors": "1.1.2"
+        "mustache": "2.3.0",
+        "request": "2.83.0",
+        "swagger-js-codegen": "1.12.0",
+        "yamljs": "0.3.0"
     },
     "devDependencies": {
         "grunt": "1.0.1",

--- a/templates/function/node.html.mustache
+++ b/templates/function/node.html.mustache
@@ -43,7 +43,7 @@
 <script type="text/javascript">
     RED.nodes.registerType('{{&nodeName}}',{
         color:"#C0DEED",
-        category: 'function',
+        category: '{{&category}}',
         defaults: {
             name: {value:""},
             func: {value:"\nreturn msg;"},

--- a/templates/function/package.json.mustache
+++ b/templates/function/package.json.mustache
@@ -9,6 +9,8 @@
         }
     },
     "keywords": [
-        "node-red-nodegen"
+        {{#keywords}}
+        "{{name}}"{{^last}}, {{/last}}
+        {{/keywords}}
     ]
 }

--- a/templates/swagger/node.html.mustache
+++ b/templates/swagger/node.html.mustache
@@ -1,6 +1,6 @@
 <script type="text/javascript">
     RED.nodes.registerType('{{&nodeName}}',{
-        category: 'function',
+        category: '{{&category}}',
         color: '#89bf04',
         defaults: {
             service: { value: "", type: "{{&nodeName}}-service", required: true },

--- a/templates/swagger/package.json.mustache
+++ b/templates/swagger/package.json.mustache
@@ -9,7 +9,9 @@
         }
     },
     "keywords": [
-        "node-red-nodegen"
+        {{#keywords}}
+        "{{name}}"{{^last}}, {{/last}}
+        {{/keywords}}
     ],
     "dependencies": {
         "q": "1.5.1",

--- a/test/lib/nodegen_spec.js
+++ b/test/lib/nodegen_spec.js
@@ -66,6 +66,20 @@ describe('nodegen library', function () {
             del.sync(result);
             done();
         });
+        it('should handle parameters (keywords)', function (done) {
+            var options = {};
+            var data = {
+                keywords: 'node-red,function,lowercase',
+                dst: '.'
+            };
+            data.src = fs.readFileSync('samples/lower-case.js');
+            var result = nodegen.function2node(data, options);
+            var packageSourceCode = JSON.parse(fs.readFileSync(result + '/package.json'));
+            packageSourceCode.name.should.equal('node-red-contrib-lowercase');
+            packageSourceCode.keywords.should.eql(['node-red-nodegen', 'node-red', 'function', 'lowercase']);
+            del.sync(result);
+            done();
+        });        
         it('should handle options', function (done) {
             var options = {
                 tgz: true,


### PR DESCRIPTION
fix swagger templates to correctly handle code generation in case of token authorization

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes

Describe the nature of this change. What problem does it address?

I added two new configuration options, to increase the flexibility of code generation:

'--keywords' option in command line to set additional keywords on the generated node along the default, 'node-red-node gen'

'--category' option in command line to configure node category instead of the default, 'function'

## Checklist
_Put an `x` in the boxes that apply_

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality

