### PR TITLE
sanitize operationId in swagger definition

### DIFF
--- a/lib/nodegen.js
+++ b/lib/nodegen.js
@@ -199,6 +199,8 @@ function swagger2node(data, options) {
             }
         } else if (key === 'default') { // 3. Handle swagger-js-codegen bug
             return undefined;
+        } else if (key === 'operationId') { // 4. Sanitize 'operationId' (remove special chars)
+			return value.replace(/(?!\w|\s)./g, '');
         } else {
             return value;
         }


### PR DESCRIPTION
remove special chars in swagger 'operationId', because this property is used in code generation tools for method names, and it can lead to invalid code

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Describe the nature of this change. What problem does it address?

## Checklist
_Put an `x` in the boxes that apply_

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality

