### PR TITLE
Remove duplicated error message

### DIFF
--- a/lib/nodegen.js
+++ b/lib/nodegen.js
@@ -120,7 +120,7 @@ function function2node(data, options) {
 
         if (data.module) {
             if (data.prefix) {
-                reject('error: module name and prefix are conflicted.');
+                reject('module name and prefix are conflicted.');
                 return;
             }
         } else {


### PR DESCRIPTION
## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
node-red-nodegen command shows the following error message when user inputs both module name and prefix.
"Error: error: module name and prefix are conflicted."
Because the message contains "error" two times, I deleted the second one.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
