### PR TITLE
Fix problem when add test cases under test/nodegen directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # Generated nodes
 node-red-contrib-*
 node-red-node-*
-nodegen
+./nodegen
 
 # Dependency directory
 node_modules


### PR DESCRIPTION
## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
In the current .gitignore setting, developers cannot add test case files under "/test/nodegen" directory because the setting ignore both "/nodegen" and "/test/nodegen" directories.
Therefore, I added slash character, "/" to ignore only "/nodegen" directory which has generated nodes.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality