### PR TITLE
Fix delete bug for library test cases

### DIFF
--- a/test/lib/nodegen_spec.js
+++ b/test/lib/nodegen_spec.js
@@ -98,7 +98,8 @@ describe('nodegen library', function () {
                 del.sync(result);
                 var jsfile = result.replace(/-[0-9]+\.[0-9]+\.[0-9]+\.tgz$/, '/node.js');
                 fs.readFileSync(jsfile).toString().split('\n').length.should.be.eql(1);
-                del.sync(jsfile);
+                result = result.replace(/-[0-9]+\.[0-9]+\.[0-9]+\.tgz$/, '');
+                del.sync(result);
                 done();
             });
         });
@@ -145,7 +146,8 @@ describe('nodegen library', function () {
                     del.sync(result);
                     var jsfile = result.replace(/-[0-9]+\.[0-9]+\.[0-9]+\.tgz$/, '/node.js');
                     fs.readFileSync(jsfile).toString().split('\n').length.should.be.eql(1);
-                    del.sync(jsfile);
+                    result = result.replace(/-[0-9]+\.[0-9]+\.[0-9]+\.tgz$/, '');
+                    del.sync(result);
                     done();
                 });
             });


### PR DESCRIPTION
## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
Test case for node generator library doesn't remove all files in generated node after the node is tested.
Therefore, I modified the deleting handling.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality