### PR TITLE
Modify indent size in package.json

### DIFF
--- a/templates/function/package.json.mustache
+++ b/templates/function/package.json.mustache
@@ -1,23 +1,24 @@
 {
-    "name": "{{&projectName}}",
-    "version": "{{&projectVersion}}",
-    "description": "Node-RED node for {{&nodeName}}",
-    "main": "node.js",
-    "scripts": {
-        "test": "mocha \"test/**/*_spec.js\""
-    },
-    "node-red": {
-        "nodes": {
-            "{{&nodeName}}": "node.js"
-        }
-    },
-    "keywords": [
-        {{#keywords}}
-        "{{name}}"{{^last}}, {{/last}}
-        {{/keywords}}
-    ],
-    "devDependencies": {
-      "node-red":"0.18.7",
-      "node-red-node-test-helper": "0.1.8"
+  "name": "{{&projectName}}",
+  "version": "{{&projectVersion}}",
+  "description": "Node-RED node for {{&nodeName}}",
+  "main": "node.js",
+  "scripts": {
+    "test": "mocha \"test/**/*_spec.js\""
+  },
+  "node-red": {
+    "nodes": {
+      "{{&nodeName}}": "node.js"
     }
+  },
+  "keywords": [
+    {{#keywords}}
+    "{{name}}"{{^last}}, {{/last}}
+    {{/keywords}}
+  ],
+  "devDependencies": {
+    "node-red": "0.18.7",
+    "node-red-node-test-helper": "0.1.8"
+  },
+  "license": "Apache-2.0"
 }

--- a/templates/swagger/package.json.mustache
+++ b/templates/swagger/package.json.mustache
@@ -1,29 +1,29 @@
 {
-    "name": "{{&projectName}}",
-    "version": "{{&projectVersion}}",
-    "description": "Node-RED node for {{&nodeName}}",
-    "main": "node.js",
-    "scripts": {
-        "test": "mocha \"test/**/*_spec.js\""
-    },
-    "node-red": {
-        "nodes": {
-            "{{&nodeName}}": "node.js"
-        }
-    },
-    "keywords": [
-        {{#keywords}}
-        "{{name}}"{{^last}}, {{/last}}
-        {{/keywords}}
-    ],
-    "dependencies": {
-        "q": "1.5.1",
-        "request": "2.83.0"
-    },
-    "devDependencies": {
-      "node-red":"0.18.7",
-      "node-red-node-test-helper": "0.1.8"
-    },
-    "author": "{{&contactName}}",
-    "license": "{{&licenseName}}"
+  "name": "{{&projectName}}",
+  "version": "{{&projectVersion}}",
+  "description": "Node-RED node for {{&nodeName}}",
+  "main": "node.js",
+  "scripts": {
+    "test": "mocha \"test/**/*_spec.js\""
+  },
+  "node-red": {
+    "nodes": {
+      "{{&nodeName}}": "node.js"
+    }
+  },
+  "keywords": [
+    {{#keywords}}
+    "{{name}}"{{^last}}, {{/last}}
+    {{/keywords}}
+  ],
+  "dependencies": {
+    "q": "1.5.1",
+    "request": "2.83.0"
+  },
+  "devDependencies": {
+    "node-red": "0.18.7",
+    "node-red-node-test-helper": "0.1.8"
+  },
+  "author": "{{&contactName}}",
+  "license": "{{&licenseName}}"
 }


### PR DESCRIPTION
## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
Current node generator generates package.json file which has four spaces as indent. npm init command generates package.json file whose indent size is two spaces. Therefore, all lines will be changed when npm init command modifies package.json file generated from node generator. To solve the problem, I changed indent size in package.json templates.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality

