### PR TITLE
Fix unnecessary configuration node

### DIFF
--- a/lib/nodegen.js
+++ b/lib/nodegen.js
@@ -331,6 +331,7 @@ function swagger2node(data, options) {
                 return params.split(',').filter(p => p).some(p => p !== 'body') ? render(content) : '';
             }
         };
+        var hasServiceParams = swagger.host === undefined || swagger.security !== undefined;
 
         // Create node.js
         var nodeSourceCode = CodeGen.getCustomCode({
@@ -344,7 +345,8 @@ function swagger2node(data, options) {
             mustache: {
                 nodeName: data.name,
                 isBodyParam: isBodyParam,
-                isNotBodyParam: isNotBodyParam
+                isNotBodyParam: isNotBodyParam,
+                hasServiceParams: hasServiceParams 
             },
             lint: false,
             beautify: false
@@ -367,7 +369,8 @@ function swagger2node(data, options) {
                 nodeName: data.name,
                 category: data.category || 'function',
                 isNotBodyParam: isNotBodyParam,
-                hasOptionalParams: hasOptionalParams
+                hasOptionalParams: hasOptionalParams,
+                hasServiceParams: hasServiceParams 
             },
             lint: false,
             beautify: false
@@ -407,6 +410,7 @@ function swagger2node(data, options) {
             mustache: {
                 nodeName: data.name,
                 projectName: data.module,
+                hasServiceParams: hasServiceParams 
             },
             lint: false,
             beautify: false

--- a/templates/swagger/node.html.mustache
+++ b/templates/swagger/node.html.mustache
@@ -1,15 +1,17 @@
 <script type="text/javascript">
-    RED.nodes.registerType('{{&nodeName}}',{
+    RED.nodes.registerType('{{&nodeName}}', {
         category: '{{&category}}',
         color: '#89bf04',
         defaults: {
+            {{#hasServiceParams}}
             service: { value: "", type: "{{&nodeName}}-service", required: true },
+            {{/hasServiceParams}}
             method: { value: "" },
 
             {{#methods}}
             {{#parameters}}
             {{&methodName}}_{{&camelCaseName}}: { value: "" },
-            {{&methodName}}_{{&camelCaseName}}Type: {value: "str"},
+            {{&methodName}}_{{&camelCaseName}}Type: { value: "str" },
             {{/parameters}}
             {{/methods}}
 
@@ -18,10 +20,10 @@
         inputs: 1,
         outputs: 1,
         icon: "icon.png",
-        label: function() {
+        label: function () {
             return this.name || "{{&nodeName}}";
         },
-        oneditprepare: function() {
+        oneditprepare: function () {
             var selectedMethod = $('#node-input-method option:selected');
             if (!selectedMethod.val()) {
                 var methods = $('#node-input-method').children();
@@ -29,7 +31,7 @@
                 $('#node-input-method').val(firstMethod.val());
             }
 
-            var showParameters = function() {
+            var showParameters = function () {
                 {{#methods}}
                 {{#parameters}}
 
@@ -86,11 +88,11 @@
                 }
             };
 
-            $("#node-input-method").change(function() {
+            $("#node-input-method").change(function () {
                 showParameters();
             });
 
-            $("#optional-parameters").change(function() {
+            $("#optional-parameters").change(function () {
                 showParameters();
             });
 
@@ -113,10 +115,12 @@
 </script>
 
 <script type="text/x-red" data-template-name="{{&nodeName}}">
+    {{#hasServiceParams}}
     <div class="form-row">
         <label for="node-input-service"><i class="fa fa-cloud"></i> <span data-i18n="{{&className}}.label.service"></span></label>
         <input type="text" id="node-input-service">
     </div>
+    {{/hasServiceParams}}
 
     <div class="form-row">
         <label for="node-input-method"><i class="icon-tasks"></i> <span data-i18n="{{&className}}.label.method"></span></label>
@@ -174,9 +178,9 @@
         <h4>{{&summary}}</h4>
     {{/methods}}
 </script>
-
+{{#hasServiceParams}}
 <script type="text/javascript">
-    RED.nodes.registerType('{{&nodeName}}-service',{
+    RED.nodes.registerType('{{&nodeName}}-service', {
         category: 'config',
         defaults: {
             {{^domain}}
@@ -211,10 +215,10 @@
             {{/isSecure}}
             temp: { type:"text" }
         },
-        label: function() {
+        label: function () {
             return this.name;
         },
-        oneditprepare: function() {
+        oneditprepare: function () {
             {{#isSecure}}
             {{#isSecureToken}}
             $('#node-config-input-secureTokenHeaderOrQueryName-label').hide();
@@ -306,3 +310,4 @@
     {{/isSecureBasic}}
     {{/isSecure}}
 </script>
+{{/hasServiceParams}}

--- a/templates/swagger/node.js.mustache
+++ b/templates/swagger/node.js.mustache
@@ -4,7 +4,9 @@ var lib = require('./lib.js');
 module.exports = function (RED) {
     function {{&className}}Node(config) {
         RED.nodes.createNode(this, config);
+        {{#hasServiceParams}}
         this.service = RED.nodes.getNode(config.service);
+        {{/hasServiceParams}}
         this.method = config.method;
 
         {{#methods}}
@@ -97,8 +99,10 @@ module.exports = function (RED) {
             }
         });
     }
+
     RED.nodes.registerType("{{&nodeName}}", {{&className}}Node);
 
+    {{#hasServiceParams}}
     function {{&className}}ServiceNode(n) {
         RED.nodes.createNode(this, n);
         {{^domain}}
@@ -122,6 +126,7 @@ module.exports = function (RED) {
         {{/isSecureBasic}}
         {{/isSecure}}
     }
+
     RED.nodes.registerType("{{&nodeName}}-service", {{&className}}ServiceNode, {
         credentials: {
             {{#isSecure}}
@@ -139,4 +144,5 @@ module.exports = function (RED) {
             temp: { type: "text" }
         }
     });
+    {{/hasServiceParams}}
 };

--- a/templates/swagger/test/node_spec.js.mustache
+++ b/templates/swagger/test/node_spec.js.mustache
@@ -1,6 +1,6 @@
-var should = require("should");
-var helper = require("node-red-node-test-helper");
-var node = require("../node.js");
+var should = require('should');
+var helper = require('node-red-node-test-helper');
+var node = require('../node.js');
 
 helper.init(require.resolve('node-red'));
 
@@ -19,9 +19,9 @@ describe('{{&nodeName}} node', function () {
     });
 
     it('should be loaded', function (done) {
-        var flow = [{ id: "n1", type: "{{&nodeName}}", name: "{{&nodeName}}" }];
+        var flow = [{ id: 'n1', type: '{{&nodeName}}', name: '{{&nodeName}}' }];
         helper.load(node, flow, function () {
-            var n1 = helper.getNode("n1");
+            var n1 = helper.getNode('n1');
             n1.should.have.property('name', '{{&nodeName}}');
             done();
         });
@@ -30,19 +30,26 @@ describe('{{&nodeName}} node', function () {
     {{#methods}}
     it('should handle {{&methodName}}()', function (done) {
         var flow = [
-            { id: "n1", type: "{{&nodeName}}", name: "{{&nodeName}}", wires: [["n2"]],
-                method: "{{&methodName}}",
+            { id: 'n1', type: '{{&nodeName}}', name: '{{&nodeName}}',
+                method: '{{&methodName}}',
                 {{#parameters}}
-                {{&methodName}}_{{&camelCaseName}}: "<node property>", // (1) define node properties
+                {{&methodName}}_{{&camelCaseName}}: '<node property>', // (1) define node properties
                 {{/parameters}}
-                service: "n3" },
-            { id: "n2", type: "{{&nodeName}}-service" },
-            { id: "n3", type: "helper" }
+            {{#hasServiceParams}}
+                wires: [['n3']],
+                service: 'n2' },
+            { id: 'n2', type: '{{&nodeName}}-service', host: 'http://<host name>' }, // (4) define host name
+            {{/hasServiceParams}}
+            {{^hasServiceParams}}
+                wires: [['n3']]
+            },
+            {{/hasServiceParams}}
+            { id: 'n3', type: 'helper' }
         ];
         helper.load(node, flow, function () {
-            var n3 = helper.getNode("n3");
-            var n1 = helper.getNode("n1");
-            n3.on("input", function (msg) {
+            var n3 = helper.getNode('n3');
+            var n1 = helper.getNode('n1');
+            n3.on('input', function (msg) {
                 try {
                     msg.should.have.property('payload', '<output message>'); // (3) define output message
                     done();
@@ -50,9 +57,8 @@ describe('{{&nodeName}} node', function () {
                     done(e);
                 }
             });
-            n1.receive({ payload: "<input message>" }); // (2) define input message
+            n1.receive({ payload: '<input message>' }); // (2) define input message
         });
     });
     {{/methods}}
 });
-

--- a/test/nodegen/node-red-contrib-swagger-petstore/node_spec.js
+++ b/test/nodegen/node-red-contrib-swagger-petstore/node_spec.js
@@ -41,13 +41,12 @@ describe('node-red-contrib-swagger-petstore', function () {
         });
     });
     it('should handle addPet()', function (done) {
-        var flow = [{id: "n1", type: "swagger-petstore", wires: [["n3"]], service: "n2", method: "addPet"},
-                    {id: "n2", type: "swagger-petstore-service"},
-                    {id: "n3", type: "helper"}];
+        var flow = [{id: "n1", type: "swagger-petstore", wires: [["n2"]], method: "addPet"},
+                    {id: "n2", type: "helper"}];
         helper.load(swaggerNode, flow, function () {
             var n1 = helper.getNode('n1');
-            var n3 = helper.getNode('n3');
-            n3.on('input', function (msg) {
+            var n2 = helper.getNode('n2');
+            n2.on('input', function (msg) {
                 try {
                     msg.payload.should.eql({
                         "id": 4513,
@@ -95,13 +94,12 @@ describe('node-red-contrib-swagger-petstore', function () {
         });
     });
     it('should handle updatePet()', function (done) {
-        var flow = [{id: "n1", type: "swagger-petstore", wires: [["n3"]], service: "n2", method: "updatePet"},
-                    {id: "n2", type: "swagger-petstore-service"},
-                    {id: "n3", type: "helper"}];
+        var flow = [{id: "n1", type: "swagger-petstore", wires: [["n2"]], method: "updatePet"},
+                    {id: "n2", type: "helper"}];
         helper.load(swaggerNode, flow, function () {
             var n1 = helper.getNode('n1');
-            var n3 = helper.getNode('n3');
-            n3.on('input', function (msg) {
+            var n2 = helper.getNode('n2');
+            n2.on('input', function (msg) {
                 try {
                     msg.payload.should.eql({
                         "id": 4513,
@@ -149,13 +147,12 @@ describe('node-red-contrib-swagger-petstore', function () {
         });
     });
     it('should handle findPetsByStatus()', function (done) {
-        var flow = [{id: "n1", type: "swagger-petstore", wires: [["n3"]], service: "n2", method: "findPetsByStatus", findPetsByStatus_status: "available"},
-                    {id: "n2", type: "swagger-petstore-service"},
-                    {id: "n3", type: "helper"}];
+        var flow = [{id: "n1", type: "swagger-petstore", wires: [["n2"]], method: "findPetsByStatus", findPetsByStatus_status: "available"},
+                    {id: "n2", type: "helper"}];
         helper.load(swaggerNode, flow, function () {
             var n1 = helper.getNode('n1');
-            var n3 = helper.getNode('n3');
-            n3.on('input', function (msg) {
+            var n2 = helper.getNode('n2');
+            n2.on('input', function (msg) {
                 try {
                     msg.payload.should.containEql({
                         "id": 4513,
@@ -184,13 +181,12 @@ describe('node-red-contrib-swagger-petstore', function () {
         });
     });
     it('should handle getPetById()', function (done) {
-        var flow = [{id: "n1", type: "swagger-petstore", wires: [["n3"]], service: "n2", method: "getPetById", getPetById_petId: "4513"},
-                    {id: "n2", type: "swagger-petstore-service"},
-                    {id: "n3", type: "helper"}];
+        var flow = [{id: "n1", type: "swagger-petstore", wires: [["n2"]], method: "getPetById", getPetById_petId: "4513"},
+                    {id: "n2", type: "helper"}];
         helper.load(swaggerNode, flow, function () {
             var n1 = helper.getNode('n1');
-            var n3 = helper.getNode('n3');
-            n3.on('input', function (msg) {
+            var n2 = helper.getNode('n2');
+            n2.on('input', function (msg) {
                 try {
                     msg.payload.should.containEql({
                         "id": 4513,
@@ -219,13 +215,12 @@ describe('node-red-contrib-swagger-petstore', function () {
         });
     });
     it('should handle updatePetWithForm()', function (done) {
-        var flow = [{id: "n1", type: "swagger-petstore", wires: [["n3"]], service: "n2", method: "updatePetWithForm", updatePetWithForm_petId: "4513", updatePetWithForm_name: "pending doggie", updatePetWithForm_status: "pending"},
-                    {id: "n2", type: "swagger-petstore-service"},
-                    {id: "n3", type: "helper"}];
+        var flow = [{id: "n1", type: "swagger-petstore", wires: [["n2"]], method: "updatePetWithForm", updatePetWithForm_petId: "4513", updatePetWithForm_name: "pending doggie", updatePetWithForm_status: "pending"},
+                    {id: "n2", type: "helper"}];
         helper.load(swaggerNode, flow, function () {
             var n1 = helper.getNode('n1');
-            var n3 = helper.getNode('n3');
-            n3.on('input', function (msg) {
+            var n2 = helper.getNode('n2');
+            n2.on('input', function (msg) {
                 try {
                     msg.should.have.property('payload', 'foo');
                     msg.should.have.property('topic', 'bar');
@@ -238,13 +233,12 @@ describe('node-red-contrib-swagger-petstore', function () {
         });
     });
     it('should handle deletePet()', function (done) {
-        var flow = [{id: "n1", type: "swagger-petstore", wires: [["n3"]], service: "n2", method: "deletePet", deletePet_petId: "4513"},
-                    {id: "n2", type: "swagger-petstore-service"},
-                    {id: "n3", type: "helper"}];
+        var flow = [{id: "n1", type: "swagger-petstore", wires: [["n2"]], method: "deletePet", deletePet_petId: "4513"},
+                    {id: "n2", type: "helper"}];
         helper.load(swaggerNode, flow, function () {
             var n1 = helper.getNode('n1');
-            var n3 = helper.getNode('n3');
-            n3.on('input', function (msg) {
+            var n2 = helper.getNode('n2');
+            n2.on('input', function (msg) {
                 try {
                     msg.should.have.property('payload', 'foo');
                     msg.should.have.property('topic', 'bar');
@@ -257,13 +251,12 @@ describe('node-red-contrib-swagger-petstore', function () {
         });
     });
     it('should handle getInventory()', function (done) {
-        var flow = [{id: "n1", type: "swagger-petstore", wires: [["n3"]], service: "n2", method: "getInventory"},
-                    {id: "n2", type: "swagger-petstore-service"},
-                    {id: "n3", type: "helper"}];
+        var flow = [{id: "n1", type: "swagger-petstore", wires: [["n2"]], method: "getInventory"},
+                    {id: "n2", type: "helper"}];
         helper.load(swaggerNode, flow, function () {
             var n1 = helper.getNode('n1');
-            var n3 = helper.getNode('n3');
-            n3.on('input', function (msg) {
+            var n2 = helper.getNode('n2');
+            n2.on('input', function (msg) {
                 try {
                     msg.payload.should.have.property('available');
                     done();
@@ -275,13 +268,12 @@ describe('node-red-contrib-swagger-petstore', function () {
         });
     });
     it('should handle placeOrder()', function (done) {
-        var flow = [{id: "n1", type: "swagger-petstore", wires: [["n3"]], service: "n2", method: "placeOrder"},
-                    {id: "n2", type: "swagger-petstore-service"},
-                    {id: "n3", type: "helper"}];
+        var flow = [{id: "n1", type: "swagger-petstore", wires: [["n2"]], method: "placeOrder"},
+                    {id: "n2", type: "helper"}];
         helper.load(swaggerNode, flow, function () {
             var n1 = helper.getNode('n1');
-            var n3 = helper.getNode('n3');
-            n3.on('input', function (msg) {
+            var n2 = helper.getNode('n2');
+            n2.on('input', function (msg) {
                 try {
                     msg.payload.should.eql({
                         "id": 4147,
@@ -309,13 +301,12 @@ describe('node-red-contrib-swagger-petstore', function () {
         });
     });
     it('should handle getOrderById()', function (done) {
-        var flow = [{id: "n1", type: "swagger-petstore", wires: [["n3"]], service: "n2", method: "getOrderById", getOrderById_orderId: "4147"},
-                    {id: "n2", type: "swagger-petstore-service"},
-                    {id: "n3", type: "helper"}];
+        var flow = [{id: "n1", type: "swagger-petstore", wires: [["n2"]], method: "getOrderById", getOrderById_orderId: "4147"},
+                    {id: "n2", type: "helper"}];
         helper.load(swaggerNode, flow, function () {
             var n1 = helper.getNode('n1');
-            var n3 = helper.getNode('n3');
-            n3.on('input', function (msg) {
+            var n2 = helper.getNode('n2');
+            n2.on('input', function (msg) {
                 try {
                     msg.payload.should.eql({
                         "id": 4147,
@@ -334,13 +325,12 @@ describe('node-red-contrib-swagger-petstore', function () {
         });
     });
     it('should handle deleteOrder()', function (done) {
-        var flow = [{id: "n1", type: "swagger-petstore", wires: [["n3"]], service: "n2", method: "deleteOrder", deleteOrder_orderId: "4147"},
-                    {id: "n2", type: "swagger-petstore-service"},
-                    {id: "n3", type: "helper"}];
+        var flow = [{id: "n1", type: "swagger-petstore", wires: [["n2"]], method: "deleteOrder", deleteOrder_orderId: "4147"},
+                    {id: "n2", type: "helper"}];
         helper.load(swaggerNode, flow, function () {
             var n1 = helper.getNode('n1');
-            var n3 = helper.getNode('n3');
-            n3.on('input', function (msg) {
+            var n2 = helper.getNode('n2');
+            n2.on('input', function (msg) {
                 try {
                     msg.should.have.property('payload', 'foo');
                     msg.should.have.property('topic', 'bar');
@@ -353,13 +343,12 @@ describe('node-red-contrib-swagger-petstore', function () {
         });
     });
     it('should handle createUser()', function (done) {
-        var flow = [{id: "n1", type: "swagger-petstore", wires: [["n3"]], service: "n2", method: "createUser"},
-                    {id: "n2", type: "swagger-petstore-service"},
-                    {id: "n3", type: "helper"}];
+        var flow = [{id: "n1", type: "swagger-petstore", wires: [["n2"]], method: "createUser"},
+                    {id: "n2", type: "helper"}];
         helper.load(swaggerNode, flow, function () {
             var n1 = helper.getNode('n1');
-            var n3 = helper.getNode('n3');
-            n3.on('input', function (msg) {
+            var n2 = helper.getNode('n2');
+            n2.on('input', function (msg) {
                 try {
                     msg.payload.should.eql({
                         "id": 8110,
@@ -391,13 +380,12 @@ describe('node-red-contrib-swagger-petstore', function () {
         });
     });
     it('should handle createUsersWithArrayInput()', function (done) {
-        var flow = [{id: "n1", type: "swagger-petstore", wires: [["n3"]], service: "n2", method: "createUsersWithArrayInput"},
-                    {id: "n2", type: "swagger-petstore-service"},
-                    {id: "n3", type: "helper"}];
+        var flow = [{id: "n1", type: "swagger-petstore", wires: [["n2"]], method: "createUsersWithArrayInput"},
+                    {id: "n2", type: "helper"}];
         helper.load(swaggerNode, flow, function () {
             var n1 = helper.getNode('n1');
-            var n3 = helper.getNode('n3');
-            n3.on('input', function (msg) {
+            var n2 = helper.getNode('n2');
+            n2.on('input', function (msg) {
                 try {
                     msg.payload.should.eql([
                         {
@@ -433,13 +421,12 @@ describe('node-red-contrib-swagger-petstore', function () {
         });
     });
     it('should handle createUsersWithListInput()', function (done) {
-        var flow = [{id: "n1", type: "swagger-petstore", wires: [["n3"]], service: "n2", method: "createUsersWithListInput"},
-                    {id: "n2", type: "swagger-petstore-service"},
-                    {id: "n3", type: "helper"}];
+        var flow = [{id: "n1", type: "swagger-petstore", wires: [["n2"]], method: "createUsersWithListInput"},
+                    {id: "n2", type: "helper"}];
         helper.load(swaggerNode, flow, function () {
             var n1 = helper.getNode('n1');
-            var n3 = helper.getNode('n3');
-            n3.on('input', function (msg) {
+            var n2 = helper.getNode('n2');
+            n2.on('input', function (msg) {
                 try {
                     msg.payload.should.eql([
                         {
@@ -475,13 +462,12 @@ describe('node-red-contrib-swagger-petstore', function () {
         });
     });
     it('should handle loginUser()', function (done) {
-        var flow = [{id: "n1", type: "swagger-petstore", wires: [["n3"]], service: "n2", method: "loginUser", loginUser_username: "My user name", loginUser_password: "My password"},
-                    {id: "n2", type: "swagger-petstore-service"},
-                    {id: "n3", type: "helper"}];
+        var flow = [{id: "n1", type: "swagger-petstore", wires: [["n2"]], method: "loginUser", loginUser_username: "My user name", loginUser_password: "My password"},
+                    {id: "n2", type: "helper"}];
         helper.load(swaggerNode, flow, function () {
             var n1 = helper.getNode('n1');
-            var n3 = helper.getNode('n3');
-            n3.on('input', function (msg) {
+            var n2 = helper.getNode('n2');
+            n2.on('input', function (msg) {
                 try {
                     msg.payload.should.startWith('logged in user session:');
                     done();
@@ -493,13 +479,12 @@ describe('node-red-contrib-swagger-petstore', function () {
         });
     });
     it('should handle logoutUser()', function (done) {
-        var flow = [{id: "n1", type: "swagger-petstore", wires: [["n3"]], service: "n2", method: "logoutUser"},
-                    {id: "n2", type: "swagger-petstore-service"},
-                    {id: "n3", type: "helper"}];
+        var flow = [{id: "n1", type: "swagger-petstore", wires: [["n2"]], method: "logoutUser"},
+                    {id: "n2", type: "helper"}];
         helper.load(swaggerNode, flow, function () {
             var n1 = helper.getNode('n1');
-            var n3 = helper.getNode('n3');
-            n3.on('input', function (msg) {
+            var n2 = helper.getNode('n2');
+            n2.on('input', function (msg) {
                 try {
                     msg.should.have.property('payload', 'foo');
                     msg.should.have.property('topic', 'bar');
@@ -512,13 +497,12 @@ describe('node-red-contrib-swagger-petstore', function () {
         });
     });
     it('should handle getUserByName()', function (done) {
-        var flow = [{id: "n1", type: "swagger-petstore", wires: [["n3"]], service: "n2", method: "getUserByName", getUserByName_username: "My user name"},
-                    {id: "n2", type: "swagger-petstore-service"},
-                    {id: "n3", type: "helper"}];
+        var flow = [{id: "n1", type: "swagger-petstore", wires: [["n2"]], method: "getUserByName", getUserByName_username: "My user name"},
+                    {id: "n2", type: "helper"}];
         helper.load(swaggerNode, flow, function () {
             var n1 = helper.getNode('n1');
-            var n3 = helper.getNode('n3');
-            n3.on('input', function (msg) {
+            var n2 = helper.getNode('n2');
+            n2.on('input', function (msg) {
                 try {
                     msg.payload.should.eql({
                         "id": 8808,
@@ -539,13 +523,12 @@ describe('node-red-contrib-swagger-petstore', function () {
         });
     });
     it('should handle updateUser()', function (done) {
-        var flow = [{id: "n1", type: "swagger-petstore", wires: [["n3"]], service: "n2", method: "updateUser", updateUser_username: "My user name"},
-                    {id: "n2", type: "swagger-petstore-service"},
-                    {id: "n3", type: "helper"}];
+        var flow = [{id: "n1", type: "swagger-petstore", wires: [["n2"]], method: "updateUser", updateUser_username: "My user name"},
+                    {id: "n2", type: "helper"}];
         helper.load(swaggerNode, flow, function () {
             var n1 = helper.getNode('n1');
-            var n3 = helper.getNode('n3');
-            n3.on('input', function (msg) {
+            var n2 = helper.getNode('n2');
+            n2.on('input', function (msg) {
                 try {
                     msg.payload.should.eql({
                         "id": 8808,
@@ -577,13 +560,12 @@ describe('node-red-contrib-swagger-petstore', function () {
         });
     });
     it('should handle deleteUser()', function (done) {
-        var flow = [{id: "n1", type: "swagger-petstore", wires: [["n3"]], service: "n2", method: "deleteUser", deleteUser_username: "My user name2"},
-                    {id: "n2", type: "swagger-petstore-service"},
-                    {id: "n3", type: "helper"}];
+        var flow = [{id: "n1", type: "swagger-petstore", wires: [["n2"]], method: "deleteUser", deleteUser_username: "My user name2"},
+                    {id: "n2", type: "helper"}];
         helper.load(swaggerNode, flow, function () {
             var n1 = helper.getNode('n1');
-            var n3 = helper.getNode('n3');
-            n3.on('input', function (msg) {
+            var n2 = helper.getNode('n2');
+            n2.on('input', function (msg) {
                 try {
                     msg.should.have.property('payload', 'foo');
                     msg.should.have.property('topic', 'bar');
@@ -596,4 +578,3 @@ describe('node-red-contrib-swagger-petstore', function () {
         });
     });
 });
-


### PR DESCRIPTION
## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
When swagger definition doesn't have host name and security setting, generated node has unnecessary configuration node (users need to input only name of configuration node). To solve the problem, I added handling to remove configuration node in the case.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality