### PR TITLE
Fix node.error() handling

### DIFF
--- a/templates/swagger/node.js.mustache
+++ b/templates/swagger/node.js.mustache
@@ -69,7 +69,7 @@ module.exports = function (RED) {
                     parameters.{{&camelCaseName}} = msg.payload;
                 } else {
                     node.error('Unsupported type: \'' + (typeof msg.payload) + '\', '
-                             + 'msg.payload must be JSON object or buffer.');
+                             + 'msg.payload must be JSON object or buffer.', msg);
                     errorFlag = true;
                 }
                 {{/isBodyParam}}
@@ -93,7 +93,7 @@ module.exports = function (RED) {
                     node.send(msg);
                     node.status({});
                 }).catch(function (error) {
-                    node.error(error);
+                    node.error(error, msg);
                     node.status({ fill: "red", shape: "ring", text: "node-red:common.status.error" });
                 });
             }


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
Current node which is generated from swagger definition cannot catch error because node.error() has only first argument. To solve the problem, I added msg variable as the second argument.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality