### PR TITLE
 Add information for error handling into swagger node template

### DIFF
--- a/templates/swagger/node.js.mustache
+++ b/templates/swagger/node.js.mustache
@@ -91,17 +91,36 @@ module.exports = function (RED) {
                 node.error('Method is not specified.', msg);
                 errorFlag = true;
             }
-
+            var setData = function (msg, data) {
+                if (data) {
+                    if (data.response) {
+                        if (data.response.statusCode) {
+                            msg.statusCode = data.response.statusCode;
+                        }
+                        if (data.response.headers) {
+                            msg.headers = data.response.headers;
+                        }
+                        if (data.response.request && data.response.request.uri && data.response.request.uri.href) {
+                            msg.responseUrl = data.response.request.uri.href;
+                        }
+                    }
+                    if (data.body) {
+                        msg.payload = data.body;
+                    }
+                }
+                return msg;
+            };
             if (!errorFlag) {
                 node.status({ fill: 'blue', shape: 'dot', text: '{{&className}}.status.requesting' });
-                result.then(function (response) {
-                    if (response.body !== null && response.body !== undefined) {
-                        msg.payload = response.body;
-                    }
-                    node.send(msg);
+                result.then(function (data) {
+                    node.send(setData(msg, data));
                     node.status({});
                 }).catch(function (error) {
-                    node.error(error, msg);
+                    var message = null;
+                    if (error && error.body && error.body.message) {
+                        message = error.body.message;
+                    }
+                    node.error(message, setData(msg, error));
                     node.status({ fill: 'red', shape: 'ring', text: 'node-red:common.status.error' });
                 });
             }

--- a/templates/swagger/node.js.mustache
+++ b/templates/swagger/node.js.mustache
@@ -66,25 +66,29 @@ module.exports = function (RED) {
             var result;
             {{#methods}}
             if (!errorFlag && node.method === '{{&methodName}}') {
-                var parameters = [], nodeParam, nodeParamType;
+                var {{&methodName}}_parameters = [];
+                var {{&methodName}}_nodeParam;
+                var {{&methodName}}_nodeParamType;
                 {{#parameters}}
                 {{#isBodyParam}}
                 if (typeof msg.payload === 'object') {
-                    parameters.{{&camelCaseName}} = msg.payload;
+                    {{&methodName}}_parameters.{{&camelCaseName}} = msg.payload;
                 } else {
-                    node.error('Unsupported type: \'' + (typeof msg.payload) + '\', '
-                             + 'msg.payload must be JSON object or buffer.', msg);
+                    node.error('Unsupported type: \'' + (typeof msg.payload) + '\', ' + 'msg.payload must be JSON object or buffer.', msg);
                     errorFlag = true;
                 }
                 {{/isBodyParam}}
                 {{#isNotBodyParam}}
-                nodeParam = node.{{&methodName}}_{{&camelCaseName}};
-                nodeParamType = node.{{&methodName}}_{{&camelCaseName}}Type;
-                parameters.{{&camelCaseName}} = nodeParamType === 'str' ? nodeParam || '' : RED.util.getMessageProperty(msg, nodeParam);
+                {{&methodName}}_nodeParam = node.{{&methodName}}_{{&camelCaseName}};
+                {{&methodName}}_nodeParamType = node.{{&methodName}}_{{&camelCaseName}}Type;
+                if ({{&methodName}}_nodeParamType === 'str') {
+                    {{&methodName}}_parameters.{{&camelCaseName}} = {{&methodName}}_nodeParam || '';
+                } else {
+                    {{&methodName}}_parameters.{{&camelCaseName}} = RED.util.getMessageProperty(msg, {{&methodName}}_nodeParam);
+                }
                 {{/isNotBodyParam}}
                 {{/parameters}}
-
-                result = client.{{&methodName}}(parameters);
+                result = client.{{&methodName}}({{&methodName}}_parameters);
             }
             {{/methods}}
             if (!errorFlag && result === undefined) {


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
When the node generated from swagger encounters an error (ex. HTTP 404), it throws the error and a catch node can catch the error in the current implementation. But the error event does not contain the details of the error. Therefore, it is difficult for the flow after catch node to handle the error. To solve this problem, I added information (same as http request node) for error handling into swagger node template.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality