### PR TITLE
Fixed the condition of `hasServiceParams`

### DIFF
--- a/lib/nodegen.js
+++ b/lib/nodegen.js
@@ -404,7 +404,7 @@ function swagger2node(data, options) {
                 return params.split(',').filter(p => p).some(p => p !== 'body') ? render(content) : '';
             };
         };
-        var hasServiceParams = swagger.host === undefined || swagger.security !== undefined;
+        var hasServiceParams = swagger.host === undefined || swagger.securityDefinitions !== undefined;
 
         // Create node.js
         var nodeSourceCode = CodeGen.getCustomCode({


### PR DESCRIPTION


<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

`swagger.security` is a definition for the whole API. It is not necessarily set when there is security on individual methods.

Therefore it is better to refer to `swagger.securityDefinitions` to see if you need ` hasServiceParams`.

`isSecure` judgment also refers to ` swagger.securityDefinitions`.

Ref: https://github.com/wcandillon/swagger-js-codegen/blob/master/lib/codegen.js#L41

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
