### PR TITLE
Add handling to modify swagger.json for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,5 @@ before_script:
   - docker pull swaggerapi/petstore
   - docker run -d -e SWAGGER_URL=http://petstore.swagger.io -e SWAGGER_BASE_PATH=/v2 -p 80:8080 swaggerapi/petstore
   - npm install -g istanbul coveralls
+  - jq '.schemes=["http"]' samples/swagger.json > samples/tmp
+  - mv samples/tmp samples/swagger.json


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
Currently, the `petstore.swagger.io` server on the Internet provides the `https` protocol only. On the other hand, the Docker image, `swaggerapi/petstore` supports the `http` protocol only. Because the defaults generated client code uses `https`, tests using the Docker image on Travis CI failed. To solve the problem, I added handling to change `https` to `http` on Travis CI only.

(Previously, the `petstore.swagger.io` server seemed to provide both `https` and `http`. Therefore, there ware no problem in [the same change](https://github.com/node-red/node-red-nodegen/blob/0.1.0/bin/getswagger.js#L27).)

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
