### PR TITLE
Output subflow information to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,12 +93,12 @@ You may need to run this with `sudo`, or from within an Administrator command sh
 
 ## Documentation
 
-- [Use cases](https://github.com/node-red/node-red-nodegen/blob/0.2.1/docs/index.md#use-cases) ([Japanese](https://github.com/node-red/node-red-nodegen/blob/0.2.1/docs/index_ja.md#use-cases))
-- [How to use Node generator](https://github.com/node-red/node-red-nodegen/blob/0.2.1/docs/index.md#how-to-use-node-generator) ([Japanese](https://github.com/node-red/node-red-nodegen/blob/0.2.1/docs/index_ja.md#how-to-use-node-generator))
-- [Generated files which node package contains](https://github.com/node-red/node-red-nodegen/blob/0.2.1/docs/index.md#generated-files-which-node-package-contains) ([Japanese](https://github.com/node-red/node-red-nodegen/blob/0.2.1/docs/index_ja.md#generated-files-which-node-package-contains))
-- [How to create a node from OpenAPI document](https://github.com/node-red/node-red-nodegen/blob/0.2.1/docs/index.md#how-to-create-a-node-from-openapi-document) ([Japanese](https://github.com/node-red/node-red-nodegen/blob/0.2.1/docs/index_ja.md#how-to-create-a-node-from-openapi-document))
-- [How to create a node from function node](https://github.com/node-red/node-red-nodegen/blob/0.2.1/docs/index.md#how-to-create-a-node-from-function-node) ([Japanese](https://github.com/node-red/node-red-nodegen/blob/0.2.1/docs/index_ja.md#how-to-create-a-node-from-function-node))
-- [How to create a node from subflow](https://github.com/node-red/node-red-nodegen/blob/0.2.1/docs/index.md#how-to-create-a-node-from-subflow) ([Japanese](https://github.com/node-red/node-red-nodegen/blob/0.2.1/docs/index_ja.md#how-to-create-a-node-from-subflow))
-- [How to create a node from WoT Thing Description](https://github.com/node-red/node-red-nodegen/blob/0.2.1/docs/index.md#how-to-create-a-node-from-wot-thing-description) ([Japanese](https://github.com/node-red/node-red-nodegen/blob/0.2.1/docs/index_ja.md#how-to-create-a-node-from-wot-thing-description))
+- [Use cases](https://github.com/node-red/node-red-nodegen/blob/0.2.2/docs/index.md#use-cases) ([Japanese](https://github.com/node-red/node-red-nodegen/blob/0.2.2/docs/index_ja.md#use-cases))
+- [How to use Node generator](https://github.com/node-red/node-red-nodegen/blob/0.2.2/docs/index.md#how-to-use-node-generator) ([Japanese](https://github.com/node-red/node-red-nodegen/blob/0.2.2/docs/index_ja.md#how-to-use-node-generator))
+- [Generated files which node package contains](https://github.com/node-red/node-red-nodegen/blob/0.2.2/docs/index.md#generated-files-which-node-package-contains) ([Japanese](https://github.com/node-red/node-red-nodegen/blob/0.2.2/docs/index_ja.md#generated-files-which-node-package-contains))
+- [How to create a node from OpenAPI document](https://github.com/node-red/node-red-nodegen/blob/0.2.2/docs/index.md#how-to-create-a-node-from-openapi-document) ([Japanese](https://github.com/node-red/node-red-nodegen/blob/0.2.2/docs/index_ja.md#how-to-create-a-node-from-openapi-document))
+- [How to create a node from function node](https://github.com/node-red/node-red-nodegen/blob/0.2.2/docs/index.md#how-to-create-a-node-from-function-node) ([Japanese](https://github.com/node-red/node-red-nodegen/blob/0.2.2/docs/index_ja.md#how-to-create-a-node-from-function-node))
+- [How to create a node from subflow](https://github.com/node-red/node-red-nodegen/blob/0.2.2/docs/index.md#how-to-create-a-node-from-subflow) ([Japanese](https://github.com/node-red/node-red-nodegen/blob/0.2.2/docs/index_ja.md#how-to-create-a-node-from-subflow))
+- [How to create a node from WoT Thing Description](https://github.com/node-red/node-red-nodegen/blob/0.2.2/docs/index.md#how-to-create-a-node-from-wot-thing-description) ([Japanese](https://github.com/node-red/node-red-nodegen/blob/0.2.2/docs/index_ja.md#how-to-create-a-node-from-wot-thing-description))
 
 Note: Currently node generator supports GET and POST methods using JSON format without authentication.

--- a/lib/subflow/index.js
+++ b/lib/subflow/index.js
@@ -89,7 +89,8 @@ module.exports = async function(data, options) {
         category: data.category || "subflow",
         description: data.desc,
         licenseName: data.license,
-        nodeRead: sf.info || ""
+        nodeRead: sf.info || "",
+        encoding: options.encoding
     };
 
     // Make directory

--- a/lib/subflow/index.js
+++ b/lib/subflow/index.js
@@ -79,6 +79,7 @@ module.exports = async function(data, options) {
     if (!data.license || (data.license === "")) {
         data.license = "unknown";
     }
+    data.info = meta.info;
 
     var params = {
         nodeName: data.name,
@@ -88,6 +89,7 @@ module.exports = async function(data, options) {
         category: data.category || "subflow",
         description: data.desc,
         licenseName: data.license,
+        nodeRead: sf.info || ""
     };
 
     // Make directory

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-nodegen",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Node generator for Node-RED",
   "homepage": "http://nodered.org",
   "main": "./lib/nodegen.js",

--- a/samples/qrcode.json
+++ b/samples/qrcode.json
@@ -3,7 +3,7 @@
         "id": "921a4b1d.07bb68",
         "type": "subflow",
         "name": "QRcode",
-        "info": "",
+        "info": "This node generates a QR code from the text data in the `msg.payload`. The QR code in the outputted `msg.payload` is text data (not image data) described by text which consists of black rectangles and white spaces. Therefore, you can use the debug node to see the QR code.\n\n### Inputs\n- `payload` - _string_\n\n  Text data which is converted to QR code\n\n### Outputs\n- `payload` - _string_\n\n  Text data which contains QR code\n\n**Note**: This node uses the [node-qrcode](https://www.npmjs.com/package/qrcode) module to generate QR codes.",
         "category": "",
         "in": [
             {

--- a/samples/qrcode.json
+++ b/samples/qrcode.json
@@ -1,1 +1,66 @@
-[{"id":"921a4b1d.07bb68","type":"subflow","name":"QRcode","info":"","category":"","in":[{"x":140,"y":120,"wires":[{"id":"e563f491.e443f8"}]}],"out":[{"x":380,"y":120,"wires":[{"id":"e563f491.e443f8","port":0}]}],"env":[],"meta":{"module":"node-red-contrib-qrcode","type":"qrcode","version":"0.1.0","author":"hiroyasu.nishiyama.uq@hitachi.com","desc":"Node-RED node for converting string to QRcode","keywords":"Node-RED, subflow, QRcode","license":"Apache-2.0"},"color":"#87A980","icon":"font-awesome/fa-qrcode"},{"id":"e563f491.e443f8","type":"function","z":"921a4b1d.07bb68","name":"","func":"qrcode.toString(msg.payload, (err,str) => {\n    if (err) {\n        node.error(err);\n        return;\n    }\n    node.send({payload: str});\n});","outputs":1,"noerr":0,"initialize":"","finalize":"","libs":[{"var":"qrcode","module":"qrcode"}],"x":260,"y":120,"wires":[[]]}]
+[
+    {
+        "id": "921a4b1d.07bb68",
+        "type": "subflow",
+        "name": "QRcode",
+        "info": "",
+        "category": "",
+        "in": [
+            {
+                "x": 140,
+                "y": 120,
+                "wires": [
+                    {
+                        "id": "e563f491.e443f8"
+                    }
+                ]
+            }
+        ],
+        "out": [
+            {
+                "x": 380,
+                "y": 120,
+                "wires": [
+                    {
+                        "id": "e563f491.e443f8",
+                        "port": 0
+                    }
+                ]
+            }
+        ],
+        "env": [],
+        "meta": {
+            "module": "node-red-contrib-qrcode",
+            "type": "qrcode",
+            "version": "0.1.0",
+            "author": "hiroyasu.nishiyama.uq@hitachi.com",
+            "desc": "Node-RED node for converting string to QRcode",
+            "keywords": "Node-RED, subflow, QRcode",
+            "license": "Apache-2.0"
+        },
+        "color": "#87A980",
+        "icon": "font-awesome/fa-qrcode"
+    },
+    {
+        "id": "e563f491.e443f8",
+        "type": "function",
+        "z": "921a4b1d.07bb68",
+        "name": "",
+        "func": "qrcode.toString(msg.payload, (err,str) => {\n    if (err) {\n        node.error(err);\n        return;\n    }\n    node.send({payload: str});\n});",
+        "outputs": 1,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [
+            {
+                "var": "qrcode",
+                "module": "qrcode"
+            }
+        ],
+        "x": 260,
+        "y": 120,
+        "wires": [
+            []
+        ]
+    }
+]

--- a/templates/subflow/README.md.mustache
+++ b/templates/subflow/README.md.mustache
@@ -3,10 +3,12 @@
 
 {{&description}}
 
-Install
--------
+## Install
 
 Run the following command in your Node-RED user directory - typically `~/.node-red`
 
         npm install {{&projectName}}
 
+## Information
+
+{{&nodeRead}}

--- a/templates/subflow/package.json.mustache
+++ b/templates/subflow/package.json.mustache
@@ -1,18 +1,21 @@
 {
-    "name": "{{&projectName}}",
-    "version": "{{&projectVersion}}",
-    "description": "Node-RED node for {{&nodeName}}",
-    "node-red": {
-        "nodes": {
-            "{{&nodeName}}": "subflow.js"
-        }
-    },
-    "keywords": [
-        {{#keywords}}
-        "{{name}}"{{^last}}, {{/last}}
-        {{/keywords}}
-    ],
-    "dependencies": {
-        "crypto-js": "4.1.1"
+  "name": "{{&projectName}}",
+  "version": "{{&projectVersion}}",
+  "description": "Node-RED node for {{&nodeName}}",
+  "keywords": [
+    {{#keywords}}
+    "{{name}}"{{^last}}, {{/last}}
+    {{/keywords}}
+  ],
+  "node-red": {
+    "nodes": {
+      "{{&nodeName}}": "subflow.js"
     }
+  },
+  {{#encoding}}
+  "dependencies": {
+    "crypto-js": "4.1.1"
+  },
+  {{/encoding}}
+  "license": "{{&licenseName}}"
 }

--- a/templates/subflow/subflow.js.mustache
+++ b/templates/subflow/subflow.js.mustache
@@ -1,11 +1,11 @@
-module.exports = function(RED) {
+module.exports = function (RED) {
     const fs = require('fs');
     const path = require("path");
-    const crypt = require("crypto-js");
-
     const file = path.join(__dirname, "subflow.json");
     const text = fs.readFileSync(file);
     const flow = JSON.parse(text);
+    {{#encoding}}
+    const crypt = require("crypto-js");
 
     function getDecoder(encoding) {
         var settings = RED.settings;
@@ -63,4 +63,8 @@ module.exports = function(RED) {
     }
 
     RED.nodes.registerSubflow(convFlow(flow));
+    {{/encoding}}
+    {{^encoding}}
+    RED.nodes.registerSubflow(flow);
+    {{/encoding}}
 }


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
I found that the generated README.md file doesn't contain the subflow node information in exporting subflow functionality. Therefore, I fixed it in this pull request.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
