### PR TITLE
Add error handling for no module property in subflow

### DIFF
--- a/bin/node-red-nodegen.js
+++ b/bin/node-red-nodegen.js
@@ -110,8 +110,7 @@ function skipBom(body) {
 
 function isSubflowDefinition(data) {
     return data.find((item) => {
-        return ((item.type === "subflow") &&
-                (item.hasOwnProperty("meta")));
+        return item.type === "subflow";
     });
 }
 
@@ -156,7 +155,6 @@ if (argv.help || argv.h) {
             promise.then(function (result) {
                 console.log('Success: ' + result);
             }).catch(function (error) {
-                console.log('Error: ' + error);
                 console.log(error.stack);
             });
         }

--- a/lib/subflow/index.js
+++ b/lib/subflow/index.js
@@ -7,7 +7,6 @@ const crypt = require("crypto-js");
 
 const TEMPLATE_DIR = path.join(__dirname,'../../templates/subflow');
 
-
 // Extract Subflow definition from JSON data
 function getSubflowDef(flow) {
     const newFlow = [];
@@ -24,9 +23,11 @@ function getSubflowDef(flow) {
             newFlow.push(item);
         }
     });
+    if (sf == null) {
+        throw new Error("No module properties in subflow");
+    }
     return [sf, newFlow];
 }
-
 
 // get flow encoding method
 function getEncoder(encoding) {
@@ -57,7 +58,6 @@ function createJSON(dstPath, flow, encoding, key) {
     const data = JSON.stringify(sf, null, 4);
     fs.writeFileSync(dstPath, data);
 }
-
 
 module.exports = async function(data, options) {
     "use strict";


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
When the subflow definition has no module properties, the current implementation mistakenly detects this definition as a function node like in https://github.com/node-red/node-red-nodegen/issues/133. To navigate the module property UI of the subflow, I added this handling to show the reason for the error.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality